### PR TITLE
Update space_age_test.cpp, as they currently do not run on the website.

### DIFF
--- a/exercises/practice/space-age/space_age_test.cpp
+++ b/exercises/practice/space-age/space_age_test.cpp
@@ -1,6 +1,6 @@
 #include "space_age.h"
 #ifdef EXERCISM_TEST_SUITE
-#include <catch2/catch.hpp>
+#include <catch2/catch_approx.hpp>
 #else
 #include "test/catch.hpp"
 #endif


### PR DESCRIPTION
Function "Approx" is not found by website test suite. Suggested fix by compiler is to rather include <catch2/catch_approx.hpp> or <catch2/catch_all.hpp>.
```
In file included from /usr/local/include/catch2/benchmark/catch_benchmark.hpp:14,
                 from /usr/local/include/catch2/benchmark/catch_benchmark_all.hpp:24,
                 from /usr/local/include/catch2/catch_all.hpp:25,
                 from /tmp/space-age/space_age_test.cpp:3:
/tmp/space-age/space_age_test.cpp: In function 'void CATCH2_INTERNAL_TEST_2()':
/tmp/space-age/space_age_test.cpp:27:31: error: 'Approx' was not declared in this scope
   27 |     REQUIRE(age.on_earth() == Approx(31.69).margin(accuracy));
      |                               ^~~~~~
/tmp/space-age/space_age_test.cpp:27:31: note: suggested alternatives:
In file included from /usr/local/include/catch2/catch_all.hpp:26:
/usr/local/include/catch2/catch_approx.hpp:17:11: note:   'Catch::Approx'
   17 |     class Approx {
      |           ^~~~~~
```
I may very well be wrong in assuming that the fix is simply to change the include statement entirely, thus including both may be what is needed. I am not knowledgable enough about the test suite to say.